### PR TITLE
Add initial prompt to runtime

### DIFF
--- a/smars-agent/README.md
+++ b/smars-agent/README.md
@@ -48,6 +48,9 @@ cargo build --release
 
 # Enable verbose logging
 ./target/release/smars-agent --spec test-plans/example-plan.smars.md --plan complex_workflow_plan --verbose
+
+# Run deterministic runtime loop with an initial prompt
+./target/release/smars-agent runtime --spec test-plans/example-plan.smars.md --prompt "Initialize analysis"
 ```
 
 ### With FoundationModels Integration

--- a/smars-agent/src/main.rs
+++ b/smars-agent/src/main.rs
@@ -78,6 +78,10 @@ enum Commands {
         /// Plan name to execute
         #[arg(short, long)]
         plan: Option<String>,
+
+        /// Optional initial prompt for execution
+        #[arg(short = 'p', long)]
+        prompt: Option<String>,
         
         /// Show detailed validation results
         #[arg(short = 'd', long)]
@@ -115,8 +119,8 @@ async fn main() -> Result<()> {
         Some(Commands::Report { trace_dir }) => {
             report_command(trace_dir).await
         }
-        Some(Commands::Runtime { spec, plan, detailed }) => {
-            runtime_command(spec, plan, detailed, cli.verbose).await
+        Some(Commands::Runtime { spec, plan, prompt, detailed }) => {
+            runtime_command(spec, plan, prompt, detailed, cli.verbose).await
         }
         Some(Commands::AgentDemo { comprehensive }) => {
             agent_demo_command(comprehensive, cli.verbose).await
@@ -241,8 +245,9 @@ async fn report_command(trace_dir: String) -> Result<()> {
 }
 
 async fn runtime_command(
-    spec: PathBuf, 
-    plan: Option<String>, 
+    spec: PathBuf,
+    plan: Option<String>,
+    prompt: Option<String>,
     detailed: bool,
     verbose: bool
 ) -> Result<()> {
@@ -255,10 +260,13 @@ async fn runtime_command(
     let mut runtime = DeterministicRuntimeLoop::new();
     
     // Execute plan with deterministic runtime loop
-    match runtime.execute_plan(&spec_content) {
+    match runtime.execute_plan(&spec_content, prompt.as_deref()) {
         Ok(execution) => {
             println!("Deterministic Runtime Execution Results");
             println!("=====================================");
+            if let Some(p) = &execution.initial_prompt {
+                println!("Initial Prompt: {}", p);
+            }
             println!("Execution ID: {}", execution.execution_id);
             println!("Plan ID: {}", execution.plan_id);
             println!("Deterministic Seed: {}", execution.deterministic_seed);

--- a/smars-agent/src/runtime_loop.rs
+++ b/smars-agent/src/runtime_loop.rs
@@ -8,6 +8,7 @@ pub struct PlanExecution {
     pub execution_id: String,
     pub plan_id: String,
     pub deterministic_seed: u64,
+    pub initial_prompt: Option<String>,
     pub execution_state: ExecutionState,
     pub feedback_collection: FeedbackCollection,
     pub validation_results: ValidationResults,
@@ -139,7 +140,7 @@ impl DeterministicRuntimeLoop {
         }
     }
 
-    pub fn execute_plan(&mut self, plan_spec: &str) -> Result<PlanExecution, ExecutionError> {
+    pub fn execute_plan(&mut self, plan_spec: &str, initial_prompt: Option<&str>) -> Result<PlanExecution, ExecutionError> {
         let execution_id = Uuid::new_v4().to_string();
         let deterministic_seed = self.generate_deterministic_seed();
         
@@ -147,6 +148,7 @@ impl DeterministicRuntimeLoop {
             execution_id: execution_id.clone(),
             plan_id: self.extract_plan_id(plan_spec)?,
             deterministic_seed,
+            initial_prompt: initial_prompt.map(|s| s.to_string()),
             execution_state: ExecutionState::Running,
             feedback_collection: FeedbackCollection {
                 execution_feedback: Vec::new(),
@@ -369,7 +371,7 @@ mod tests {
             )
         "#;
 
-        let result = runtime.execute_plan(plan_spec);
+        let result = runtime.execute_plan(plan_spec, None);
         assert!(result.is_ok());
         
         let execution = result.unwrap();
@@ -386,6 +388,7 @@ mod tests {
             execution_id: "test".to_string(),
             plan_id: "test_plan".to_string(),
             deterministic_seed: 12345,
+            initial_prompt: None,
             execution_state: ExecutionState::Running,
             feedback_collection: FeedbackCollection {
                 execution_feedback: Vec::new(),


### PR DESCRIPTION
## Summary
- add `initial_prompt` field to `PlanExecution`
- allow deterministic runtime loop to accept a prompt
- expose `--prompt` option in CLI runtime command
- document prompt execution in smars-agent README

## Testing
- `cargo test --no-run` *(fails: failed to download from https://index.crates.io)*

------
https://chatgpt.com/codex/tasks/task_e_688045566070832d8c08ef4f6a435aa8